### PR TITLE
CAN Communication

### DIFF
--- a/src/can.cpp
+++ b/src/can.cpp
@@ -5,6 +5,7 @@
 
 #ifdef _ARDUINO
 #include <Arduino.h>
+#include <AltSoftSerial.h>
 #include <SoftwareSerial.h>
 #include "Serial_CAN_Module.h"
 
@@ -26,7 +27,7 @@ Serial_CAN canUp;
 Serial_CAN canDown;
 
 SoftwareSerial serUp = SoftwareSerial(CAN_UP_RX, CAN_UP_TX);
-SoftwareSerial serDown = SoftwareSerial(CAN_DOWN_RX, CAN_DOWN_TX);
+AltSoftSerial serDown;
 #endif
 
 /**
@@ -41,9 +42,6 @@ void CANSetup(void)
     canUp.begin(serUp, CAN_BAUDRATE);
     canDown.begin(serDown, CAN_BAUDRATE);
 
-    serUp.listen();
-    debugPrintLine("Resetting upstream...");
-    canUp.factorySetting();
     debugPrintLine("Setting upstream mask...");
     if (!canUp.setMask(rx_mask)) {
         debugPrintLine("Upstream mask not set");
@@ -53,9 +51,6 @@ void CANSetup(void)
         debugPrintLine("Upstream filter not set");
     }
 
-    serDown.listen();
-    debugPrintLine("Resetting downstream...");
-    canDown.factorySetting();
     debugPrintLine("Setting downstream mask...");
     if (!canDown.setMask(rx_mask)) {
         debugPrintLine("Downstream mask not set");

--- a/src/can.cpp
+++ b/src/can.cpp
@@ -5,6 +5,20 @@
 #include <Arduino.h>
 #include "Serial_CAN_Module.h"
 
+uint32_t rx_mask[4] = {
+    0x1, 0x0,
+    0x1, 0x0
+};
+
+uint32_t rx_filter[12] = {
+    0x1, 0xffffffff,
+    0x1, 0xffffffff,
+    0x1, 0xffffffff,
+    0x1, 0xffffffff,
+    0x1, 0xffffffff,
+    0x1, 0xffffffff
+};
+
 Serial_CAN canUp;
 Serial_CAN canDown;
 #endif
@@ -20,6 +34,32 @@ void CANSetup(void)
 #ifdef Arduino_h
     canUp.begin(CAN_UP_TX, CAN_UP_RX, CAN_BAUDRATE);
     canDown.begin(CAN_DOWN_TX, CAN_DOWN_RX, CAN_BAUDRATE);
+
+    debugPrintLine("Resetting upstream...");
+    canUp.factorySetting();
+    debugPrintLine("Resetting downstream...");
+    canDown.factorySetting();
+
+    debugPrintLine("Setting upstream mask...");
+    if (!canUp.setMask(rx_mask)) {
+        debugPrintLine("Upstream mask not set");
+    }
+
+    debugPrintLine("Setting downstream mask...");
+    if (!canDown.setMask(rx_mask)) {
+        debugPrintLine("Downstream mask not set");
+    }
+
+    debugPrintLine("Setting upstream filter...");
+    if (!canUp.setFilt(rx_filter)) {
+        debugPrintLine("Upstream filter not set");
+    }
+
+    debugPrintLine("Setting downstream filter...");
+    if (!canDown.setFilt(rx_filter)) {
+        debugPrintLine("Downstream filter not set");
+    }
+
 #endif
 }
 

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -24,9 +24,7 @@ inline uint32_t cmdPGNFromMessage(message_t *message)
  */
 void cmdSendUpstream(message_t *command)
 {
-#ifdef _DBG
     debugPrintLine("Sent command!");
-#endif  // _DBG
     CANSend(UP, command->id, CAN_FRAME_EXT, 0x00, command->length, command->data);
 }
 
@@ -43,9 +41,7 @@ uint8_t cmdReceiveDownstream(message_t *command)
     uint8_t data[CAN_DATA_LEN_MAX];
 
     if ((received = CANReceive(DOWN, &id, data)) != 0x00) {
-#ifdef _DBG
         debugPrintLine("Received command!");
-#endif  // _DBG
         command->id = id;
         command->length = CAN_DATA_LEN_MAX;  // TODO Is there a way to determine the actual length?
         memcpy(command->data, data, CAN_DATA_LEN_MAX);
@@ -102,8 +98,6 @@ void cmdParse(message_t *command)
         }
     }
 
-#ifdef _DBG
     debugPrintLine("Parsed a command!");
-#endif  // _DBG
 }
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -20,9 +20,12 @@ extern message_t currentUpdate;
  */
 void debugPrint(const char *message)
 {
+#ifdef _DBG
 #ifdef Arduino_h
     Serial.print(message);
-#endif
+
+#endif  // Arduino_h
+#endif  // _DBG
 }
 
 /**
@@ -32,9 +35,11 @@ void debugPrint(const char *message)
  */
 void debugPrintLine(const char *message)
 {
+#ifdef _DBG
 #ifdef Arduino_h
     Serial.println(message);
 #endif  // Arduino_h
+#endif  // _DBG
 }
 
 /**
@@ -44,9 +49,11 @@ void debugPrintLine(const char *message)
  */
 uint32_t debugReadLine(char *buffer)
 {
+#ifdef _DBG
 #ifdef Arduino_h
     return Serial.readBytesUntil('\n', buffer, DEBUG_INPUT_LEN_MAX);
-#endif
+#endif  // Arduino_h
+#endif  // _DBG
 }
 
 /**
@@ -72,9 +79,9 @@ void debugScan(void)
  */
 void debugHandshake(void)
 {
-    currentCommand.id = 0;
-    currentCommand.length = 0;
-    memset(currentCommand.data, 0, CAN_DATA_LEN_MAX);  // Just to be safe
+    currentCommand.id = 1<<8;
+    currentCommand.length = CAN_DATA_LEN_MAX;
+    memset(currentCommand.data, 2, CAN_DATA_LEN_MAX);  // Just to be safe
 
     cmdSendUpstream(&currentCommand);
 }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -59,7 +59,7 @@ void debugScan(void)
     if (!debugReadLine(buffer))
         return;
     
-    if (strncmp(buffer, "HANDSHAKE", 9) == 0) {
+    if (strncmp(buffer, "1", 1) == 0) {
         debugHandshake();
     } else {
         debugPrintLine("Unrecognized debug command!");

--- a/src/defs.h
+++ b/src/defs.h
@@ -65,15 +65,15 @@ void cmdParse (message_t *command);
 
 // TODO These will definitely have to change
 
-#define PGN_DEBUG_HANDSHAKE 0x00
+#define PGN_DEBUG_HANDSHAKE 0x01
 
-#define PGN_TARE_START  0x01
-#define PGN_TARE_STEP1  0x02
-#define PGN_TARE_STEP2  0x03
-#define PGN_TARE_FINISH 0x04
+#define PGN_TARE_START  0x02
+#define PGN_TARE_STEP1  0x03
+#define PGN_TARE_STEP2  0x04
+#define PGN_TARE_FINISH 0x05
 
-#define PGN_CALIBRATE_START  0x05
-#define PGN_CALIBRATE_FINISH 0x06
+#define PGN_CALIBRATE_START  0x06
+#define PGN_CALIBRATE_FINISH 0x07
 
 /*********
 * UPDATE *

--- a/src/defs.h
+++ b/src/defs.h
@@ -25,8 +25,10 @@ void debugHandshake(void);
 #define CAN_BAUDRATE 9600
 #define CAN_UP_TX 4
 #define CAN_UP_RX 5
-#define CAN_DOWN_TX 6
-#define CAN_DOWN_RX 7
+
+// Downstream CAN for Arduino now uses AltSoftSerial which requires RX 8, TX 9
+// #define CAN_DOWN_TX 6
+// #define CAN_DOWN_RX 7
 
 #define CAN_FRAME_STD 0x00
 #define CAN_FRAME_EXT 0x01

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,9 +4,11 @@
 // Leave undefined in the compiler if not compiling to an Arduino target
 #ifdef _ARDUINO
 #include <Arduino.h>
+#include <AltSoftSerial.h>
 #include <SoftwareSerial.h>
 
-extern SoftwareSerial serUp, serDown;
+extern SoftwareSerial serUp;
+extern AltSoftSerial serDown;
 #endif  // _ARDUINO
 
 #include "defs.h"
@@ -19,7 +21,7 @@ message_t currentUpdate;
 
 #ifdef Arduino_h
 // Tracker for time elapsed on a given SoftwareSerial port
-uint32_t prevTime;
+// uint32_t prevTime;
 #endif  // Arduino_h
 
 // Initialization steps go in here
@@ -32,7 +34,7 @@ void setup()
     debugPrintLine("ARDUINO: Started setup");
     CANSetup();
     debugPrintLine("ARDUINO: Completed setup");
-    prevTime = millis();
+    // prevTime = millis();
 #endif  // Arduino_h
 }
 
@@ -47,38 +49,32 @@ void loop()
     debugPrintLine("ARDUINO: Debug scan");
 #endif  // _DBG
 
-    if (millis() - prevTime > 250) {
-        prevTime = millis();
-        if (serUp.isListening()) {
-            debugPrintLine("Listening down");
-            serDown.listen();
-        } else {
-            debugPrintLine("Listening up");
-            serUp.listen();
-        }
-    }
+    // if (millis() - prevTime > 250) {
+    //     prevTime = millis();
+    //     if (serUp.isListening()) {
+    //         debugPrintLine("Listening down");
+    //         serDown.listen();
+    //     } else {
+    //         debugPrintLine("Listening up");
+    //         serUp.listen();
+    //     }
+    // }
     
     // Poll for commands and respond accordingly
     // If a command is received from downstream (ECU-side) immediately forward upstream
     // Then check to see if the command requires any action from this device
-    // serDown.listen();
-    // debugPrintLine("ARDUINO: Listening down...");
     if (cmdReceiveDownstream(&currentCommand)) {
         cmdSendUpstream(&currentCommand);
         cmdParse(&currentCommand);
     }
-    // delay(1000);
 
     // Poll for updates and respond accordingly
     // If an update is received from upstream, handle (e.g. provide modifications)
     // Then forward the modified message downstream
-    // serUp.listen();
-    // debugPrintLine("ARDUINO: Listening up...");
     if (updateReceiveUpstream(&currentUpdate)) {
         updateHandle(&currentUpdate);
         updateSendDownstream(&currentUpdate);
     }
-    // delay(500);
 
 #endif  // Arduino_h
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@ void setup()
 {
 #ifdef Arduino_h
     Serial.begin(SER_BAUDRATE);
+    while (!Serial);
 #ifdef _DBG
     debugPrintLine("ARDUINO: Started setup");
 #endif  // _DBG

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,8 @@
 #ifdef _ARDUINO
 #include <Arduino.h>
 #include <SoftwareSerial.h>
+
+extern SoftwareSerial serUp, serDown;
 #endif  // _ARDUINO
 
 #include "defs.h"
@@ -45,6 +47,7 @@ void loop()
     // Poll for commands and respond accordingly
     // If a command is received from downstream (ECU-side) immediately forward upstream
     // Then check to see if the command requires any action from this device
+    serDown.listen();
     if (cmdReceiveDownstream(&currentCommand)) {
         cmdSendUpstream(&currentCommand);
         cmdParse(&currentCommand);
@@ -53,6 +56,7 @@ void loop()
     // Poll for updates and respond accordingly
     // If an update is received from upstream, handle (e.g. provide modifications)
     // Then forward the modified message downstream
+    serUp.listen();
     if (updateReceiveUpstream(&currentUpdate)) {
         updateHandle(&currentUpdate);
         updateSendDownstream(&currentUpdate);

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -23,10 +23,7 @@ uint8_t updateReceiveUpstream(message_t *update)
     uint8_t data[CAN_DATA_LEN_MAX];
 
     if ((received = CANReceive(UP, &id, data)) != 0x00) {
-#ifdef _DBG
         debugPrintLine("Received update!");
-#endif  // _DBG
-
         update->id = id;
         memcpy(update->data, data, CAN_DATA_LEN_MAX);
     }
@@ -41,10 +38,7 @@ uint8_t updateReceiveUpstream(message_t *update)
  */
 void updateSendDownstream(message_t *update)
 {
-#ifdef _DBG
     debugPrintLine("Sent update!");
-#endif  // _DBG
-
     CANSend(DOWN, update->id, CAN_FRAME_EXT, 0x00, update->length, update->data);
 }
 
@@ -59,8 +53,6 @@ void updateHandle(message_t *update)
     //  - inject mass data for this node
     //  - increment origin field by 1
     //  - ???
-#ifdef _DBG
     debugPrintLine("Update handled!");
-#endif  // _DBG
 }
 


### PR DESCRIPTION
Enables full back and forth CAN communication up and down the chain of Arduinos. Note that the downstream pins have changed from 6/7 to 8/9 and this is non-negotiable.