### PR TITLE
ADC Port & General Cleanup

### DIFF
--- a/TBD.cproj
+++ b/TBD.cproj
@@ -248,6 +248,7 @@
           </JtagDaisyChainDevices>
         </InterfaceProperties>
         <InterfaceName>SWD</InterfaceName>
+        <JlinkConfigFile>C:\Users\short\Documents\git-repos\GE495-firmware\jlink.config</JlinkConfigFile>
       </ToolOptions>
       <ToolType>com.atmel.avrdbg.tool.samice</ToolType>
       <ToolNumber>261011134</ToolNumber>

--- a/TBD.cproj
+++ b/TBD.cproj
@@ -31,13 +31,13 @@
     <AsfFrameworkConfig>
       <framework-data>
         <options>
-          <option id="sam.drivers.can" value="Add" config="" content-id="Atmel.ASF" />
           <option id="common.boards" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="common.services.basic.clock" value="Add" config="" content-id="Atmel.ASF" />
           <option id="common.services.basic.gpio" value="Add" config="" content-id="Atmel.ASF" />
           <option id="common.services.ioport" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.drivers.can" value="Add" config="" content-id="Atmel.ASF" />
           <option id="sam.drivers.pio" value="Add" config="" content-id="Atmel.ASF" />
           <option id="sam.drivers.pmc" value="Add" config="" content-id="Atmel.ASF" />
-          <option id="common.services.basic.clock" value="Add" config="" content-id="Atmel.ASF" />
           <option id="sam.utils.linker_scripts" value="Add" config="" content-id="Atmel.ASF" />
         </options>
         <configurations>

--- a/src/ASF/common/boards/digitizer/digitizer.h
+++ b/src/ASF/common/boards/digitizer/digitizer.h
@@ -36,25 +36,6 @@
                                           CLOCK SETTINGS
 ***************************************************************************************************/
 
-// External oscillator settings.
-// Uncomment and set correct values if external oscillator is used.
-
-// External oscillator frequency
-//#define BOARD_XOSC_HZ          8000000
-
-// External oscillator type.
-//!< External clock signal
-//#define BOARD_XOSC_TYPE        XOSC_TYPE_EXTERNAL
-//!< 32.768 kHz resonator on TOSC
-//#define BOARD_XOSC_TYPE        XOSC_TYPE_32KHZ
-//!< 0.4 to 16 MHz resonator on XTALS
-//#define BOARD_XOSC_TYPE        XOSC_TYPE_XTAL
-
-// External oscillator startup time
-//#define BOARD_XOSC_STARTUP_US  500000
-
-// TODO: these are default values... are they correct?
-
 /** Slow clock settings */
 #  define BOARD_FREQ_SLCK_XTAL      (32768UL)
 #  define BOARD_FREQ_SLCK_BYPASS    (32768UL)

--- a/src/ASF/common/boards/digitizer/digitizer.h
+++ b/src/ASF/common/boards/digitizer/digitizer.h
@@ -71,10 +71,30 @@
 
 
 /***************************************************************************************************
-                                            PIN MACROS
+                                          PIN MACROS - CAN
 ***************************************************************************************************/
 
-// TODO: place common pin macro names (e.g. PIO_PA3 -> SCLK, etc.)
+/** CAN0 (Downstream) PIN RX. */
+#define PIN_CAN0_RX_IDX           PIO_PB3_IDX
+#define PIN_CAN0_RX_FLAGS         IOPORT_MODE_MUX_A
 
+/** CAN0 (Downstream) PIN TX. */
+#define PIN_CAN0_TX_IDX           PIO_PB2_IDX
+#define PIN_CAN0_TX_FLAGS         IOPORT_MODE_MUX_A
+
+/** CAN1 (Upstream) PIN RX. */
+#define PIN_CAN1_RX_IDX           PIO_PC12_IDX
+#define PIN_CAN1_RX_FLAGS         IOPORT_MODE_MUX_C
+
+/** CAN1 (Upstream) PIN TX. */
+#define PIN_CAN1_TX_IDX           PIO_PC15_IDX
+#define PIN_CAN1_TX_FLAGS         IOPORT_MODE_MUX_C
+
+
+/***************************************************************************************************
+                                          PIN MACROS - ADC
+***************************************************************************************************/
+
+// TODO: pull in pin macros for ADC control
 
 #endif // DIGITIZER_H

--- a/src/adc.c
+++ b/src/adc.c
@@ -88,7 +88,7 @@ void adcInit(void)
 	adcInitPins();
 
 	// initialize ADC Speed
-	adcSetSpeed(adcSpeedSlow);
+	adcSetSpeed(adcSpeedFast);
 
 	// initialize ADC Gain
 	adcSetGain(adcGain128);

--- a/src/adc.c
+++ b/src/adc.c
@@ -23,9 +23,6 @@
 #define ADC_DATA_MAX_VALUE_MASK		((1 << ADC_READ_SIZE_BITS) - 1)
 #define ADC_BIT_MAX_VALUE_MASK		(1)
 
-#define SUCCESS				0
-#define TIMEOUT_OCCURRED	1
-
 
 #if (BOARD==SAM4E_XPLAINED_PRO)
 
@@ -243,7 +240,7 @@ static uint8_t adcWaitWhileDataLineEquals(uint8_t voltage)
 		delayFor(1);
 		delayCounter++;
 		if (delayCounter > ADC_MAX_BLOCKING_WAIT_US)
-			return TIMEOUT_OCCURRED;
+			return FAILURE;
 	};
 	return SUCCESS;
 }
@@ -260,9 +257,9 @@ static int32_t adcReadChannel(adcChannel_t channel)
 	adcSelectChannel(channel);
 	
 	// wait for data line to go low then high then low again
-	if (adcWaitWhileDataLineEquals(0) == TIMEOUT_OCCURRED)
+	if (adcWaitWhileDataLineEquals(0) == FAILURE)
 		return 0;
-	if (adcWaitWhileDataLineEquals(1) == TIMEOUT_OCCURRED)
+	if (adcWaitWhileDataLineEquals(1) == FAILURE)
 		return 0;
 
 	for (int i = ADC_READ_SIZE_BITS - 1; i>=0; i--)

--- a/src/calibration.c
+++ b/src/calibration.c
@@ -56,7 +56,6 @@ void calibrationTareAllLoadCells(void)
 {
 	for (adcChannel_t channel = adcChannelZero; channel < LOAD_CELLS_PER_TANK; channel++)
 	{
-		adcReadAndCalibrate(channel);
 		int32_t data = adcReadChannelSmooth(channel);
 		calibrationTare(channel, data);
 	}

--- a/src/calibration.c
+++ b/src/calibration.c
@@ -16,7 +16,12 @@ static float mass2 = 0.0;
 static int32_t voltage1 = 0;
 static int32_t voltage2 = 0;
 
-// static uint8_t offsetFlag = 0;
+
+/***************************************************************************************************
+                                       PRIVATE FUNCTION STUBS
+***************************************************************************************************/
+
+static void calibrationUpdateConversionFactor(void);
 
 
 /***************************************************************************************************
@@ -51,6 +56,7 @@ void calibrationTareAllLoadCells(void)
 {
 	for (adcChannel_t channel = adcChannelZero; channel < LOAD_CELLS_PER_TANK; channel++)
 	{
+		adcReadAndCalibrate(channel);
 		int32_t data = adcReadChannelSmooth(channel);
 		calibrationTare(channel, data);
 	}
@@ -61,10 +67,10 @@ void calibrationTareAllLoadCells(void)
  * Get the first mass and voltage value for calibration step one.
  * @param double mass The mass of the first point for calibration
  */
-void calibrationObtainMassOne(double mass)
+void calibrationObtainMassOne(float mass)
 {
 	mass1 = mass;
-	voltage1 = adcReadAllChannels();
+	voltage1 = adcReadAllSmooth();
 }
 
 
@@ -72,12 +78,26 @@ void calibrationObtainMassOne(double mass)
  * Get the second mass and voltage value for calibration step two.
  * @param double mass The mass of the second point for calibration
  */
-void calibrationObtainMassTwo(double mass)
+void calibrationObtainMassTwo(float mass)
 {
 	mass2 = mass;
-	voltage2 = adcReadAllChannels();
+	voltage2 = adcReadAllSmooth();
+	calibrationUpdateConversionFactor();
 }
 
+
+/**
+ * Getter function for the voltage to mass slope factor.
+ */
+float calibrationConversionFactor(void)
+{
+	return voltageToMassFactor;
+}
+
+
+/***************************************************************************************************
+                                         PRIVATE FUNCTIONS
+***************************************************************************************************/
 
 /**
  * Create the factor to convert the measured voltage from a load cell to a mass value.
@@ -86,7 +106,20 @@ void calibrationObtainMassTwo(double mass)
  * @param mass2 The mass value for the second point of reference for calibration
  * @param voltage2 The voltage value for the second point of reference for calibration
  */
-void calibrationGetConversionFactor()
+static void calibrationUpdateConversionFactor(void)
 {
-	voltageToMassFactor = (mass1 - mass2) / (voltage1 - voltage2);
+	// obtain the difference in reported mass (rise)
+	float massDifference = mass1 - mass2;
+		
+	// obtain the difference in measured voltage (run)
+	int32_t voltageDifference = voltage1 - voltage2;
+	if (voltageDifference == 0)
+		voltageDifference = 1;
+	
+	// calculate new voltage to mass scale (slope = rise/run)
+	voltageToMassFactor = massDifference / voltageDifference;
+	
+	// ensure the slope factor is never negative
+	//if (voltageToMassFactor < 0)
+		//voltageToMassFactor = (-1) * voltageToMassFactor;
 }

--- a/src/can.c
+++ b/src/can.c
@@ -10,9 +10,11 @@
 #include <asf.h>
 #include <can.h>
 #include <digitizer.h>
+#include <string.h>
 
 
 extern uint32_t systemClk;
+extern uint32_t cpuClk;
 
 volatile uint32_t g_can_up_receive_status = 0;
 volatile uint32_t g_can_down_receive_status = 0;
@@ -77,9 +79,10 @@ uint8_t CANSetup(void)
 	// Configure the downstream transmit mailbox
 	can_mbox_down_tx.ul_mb_idx = TBD_CAN_TX_IDX;
 	can_mbox_down_tx.uc_obj_type = CAN_MB_TX_MODE;
-	can_mbox_down_tx.uc_id_ver = 1;  // Extended ID
+	can_mbox_down_tx.uc_tx_prio = 15;	// Default (lowest) priority
+	can_mbox_down_tx.uc_id_ver = 1;		// Extended ID
 	can_mbox_down_tx.ul_id_msk = 0;
-	can_mbox_down_tx.ul_id = CAN_MID_MIDvA(TBD_CAN_DOWN_ADDR);  // TODO: Find proper masks for these
+	//can_mbox_down_tx.ul_id = CAN_MID_MIDvB(TBD_CAN_DOWN_ADDR);	// Extended ID (is this needed for transmitter?)
 	can_mailbox_init(TBD_CAN_DOWN, &can_mbox_down_tx);
 	
 	// Configure the downstream receive mailbox
@@ -102,8 +105,9 @@ uint8_t CANSetup(void)
 	can_mbox_up_rx.ul_mb_idx = TBD_CAN_RX_IDX;
 	can_mbox_up_rx.uc_obj_type = CAN_MB_RX_OVER_WR_MODE;
 	can_mbox_up_rx.uc_id_ver = 1;  // Extended ID
-	can_mbox_up_rx.ul_id_msk = 0;  // Accept all incoming IDs
-	can_mbox_up_rx.ul_id = CAN_MID_MIDvA(TBD_CAN_UP_ADDR);  // TODO: Find proper masks for these
+	//can_mbox_up_rx.ul_id_msk = 0;  // Accept all incoming IDs
+	can_mbox_up_rx.ul_id_msk = CAN_MAM_MIDvB_Msk;  // Accept extended ID frames
+	can_mbox_up_rx.ul_id = CAN_MID_MIDvB(TBD_CAN_UP_ADDR);  // TODO: Find proper masks for these
 	can_mailbox_init(TBD_CAN_UP, &can_mbox_up_rx);
 
 	// Enable CAN interrupts
@@ -132,19 +136,37 @@ uint8_t CANSend(direction_t direction, uint32_t id, uint8_t length, const uint8_
 			return FAILURE;
 	}
 
-	mbox->ul_id = CAN_MID_MIDvA(id) | CAN_MID_MIDvB(id);
-	for (int i = 0; i < 4; i++) {
-		mbox->ul_datal |= data[i] << (8*i);
-		mbox->ul_datah |= data[i+4] << (8*i);
-	}
+	//mbox->ul_id = CAN_MID_MIDvA(id) | CAN_MID_MIDvB(id);
+	//for (int i = 0; i < 4; i++) {
+		//mbox->ul_datal |= data[i] << (8*i);
+		//mbox->ul_datah |= data[i+4] << (8*i);
+	//}
+
+	// set the ID of the message
+	mbox->ul_id = CAN_MID_MIDvB(TBD_CAN_UP_ADDR);	// TODO: change id
+	
+	// set the low and high (4 bytes each) message contents
+	memcpy(&(mbox->ul_datal), data, sizeof(mbox->ul_datal));
+	memcpy(&(mbox->ul_datah), &data[sizeof(mbox->ul_datal)], sizeof(mbox->ul_datah));
+	
+	// set the length of the message
 	mbox->uc_length = length;
 
-	uint32_t status = can_mailbox_write(can_module, mbox);
+	uint32_t write_status = can_mailbox_write(can_module, mbox);
 
-	if (status == CAN_MAILBOX_TRANSFER_OK) {
+	uint32_t status = can_mailbox_get_status(can_module, TBD_CAN_TX_IDX);
+
+	if (write_status == CAN_MAILBOX_TRANSFER_OK) {
 		can_mailbox_send_transfer_cmd(can_module, mbox);
+
+		status = can_mailbox_get_status(can_module, TBD_CAN_TX_IDX);
+
 		return SUCCESS;
 	}
+
+	can_reset_all_mailbox(can_module);
+
+	status = can_mailbox_get_status(can_module, TBD_CAN_TX_IDX);
 	
 	return FAILURE;
 }
@@ -169,8 +191,9 @@ uint8_t CANReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t
 	if (!(can_mailbox_get_status(can_module, TBD_CAN_RX_IDX) & CAN_MSR_MRDY))
 		return FAILURE;
 	
-	uint32_t status;
-	if ((status = can_mailbox_read(can_module, mbox)) == CAN_MAILBOX_TRANSFER_OK) {
+	uint32_t status = can_mailbox_read(can_module, mbox);
+
+	if (status == CAN_MAILBOX_TRANSFER_OK) {
 		// Successful read
 		*id = mbox->ul_id;  // TODO does this need to be converted using CAN_MID_MIDvA/B?
 		*length = mbox->uc_length;

--- a/src/can.c
+++ b/src/can.c
@@ -153,6 +153,9 @@ uint8_t canTransmit(direction_t direction, uint32_t id, uint8_t length, const ui
 	// get the status of the transmit mailbox
 	uint32_t write_status = can_mailbox_write(can_module, mbox);
 
+	// get the status of the CAN peripheral
+	uint32_t status = can_get_status(can_module);
+
 	// transmit the message in the mailbox if it's ready
 	if (write_status == CAN_MAILBOX_TRANSFER_OK) {
 		can_mailbox_send_transfer_cmd(can_module, mbox);

--- a/src/can.c
+++ b/src/can.c
@@ -10,15 +10,16 @@
 #include <asf.h>
 #include <can.h>
 
+
 extern uint32_t systemClk;
 
 volatile uint32_t g_can_up_receive_status = 0;
 volatile uint32_t g_can_down_receive_status = 0;
 
-can_mb_conf_t can_mbox_down_tx;
-can_mb_conf_t can_mbox_down_rx;
-can_mb_conf_t can_mbox_up_tx;
-can_mb_conf_t can_mbox_up_rx;
+can_mb_conf_t can_mbox_down_tx = { 0 };
+can_mb_conf_t can_mbox_down_rx = { 0 };
+can_mb_conf_t can_mbox_up_tx = { 0 };
+can_mb_conf_t can_mbox_up_rx = { 0 };
 
 // Downstream
 void CAN0_Handler(void)
@@ -62,7 +63,12 @@ uint8_t CANSetup(void)
 
 	#else // (BOARD==SAM4E_XPLAINED_PRO)
 	
-	// TODO: set CAN pin settings for SAM4E8E
+	ioport_set_pin_mode(PIN_CAN1_RX_IDX, PIN_CAN1_RX_FLAGS);
+	ioport_set_pin_mode(PIN_CAN1_TX_IDX, PIN_CAN1_TX_FLAGS);
+
+	/* Configure the transiver1 RS & EN pins. */
+	ioport_set_pin_dir(PIN_CAN1_TR_RS_IDX, IOPORT_DIR_OUTPUT);
+	ioport_set_pin_dir(PIN_CAN1_TR_EN_IDX, IOPORT_DIR_OUTPUT);
 	
 	#endif // (BOARD==SAM4E_XPLAINED_PRO)
 

--- a/src/can.c
+++ b/src/can.c
@@ -9,6 +9,7 @@
 
 #include <asf.h>
 #include <can.h>
+#include <digitizer.h>
 
 
 extern uint32_t systemClk;
@@ -17,24 +18,24 @@ volatile uint32_t g_can_up_receive_status = 0;
 volatile uint32_t g_can_down_receive_status = 0;
 
 can_mb_conf_t can_mbox_down_tx = { 0 };
-can_mb_conf_t can_mbox_down_rx = { 0 };
-can_mb_conf_t can_mbox_up_tx = { 0 };
+//can_mb_conf_t can_mbox_down_rx = { 0 };
+//can_mb_conf_t can_mbox_up_tx = { 0 };
 can_mb_conf_t can_mbox_up_rx = { 0 };
 
-// Downstream
-void CAN0_Handler(void)
-{
-	uint32_t status;
-	status = can_mailbox_get_status(CAN0, TBD_CAN_RX_IDX);
-	if ((status & CAN_MSR_MRDY) == CAN_MSR_MRDY) {
-		can_mbox_up_rx.ul_mb_idx = TBD_CAN_RX_IDX;  // I don't know why or even if this is important
-		can_mbox_up_rx.ul_status = status;
-		can_mailbox_read(CAN0, &can_mbox_up_rx);
-		g_can_down_receive_status = 1;
-	}
-}
+// Downstream Receive Interrupt Handler
+//void CAN0_Handler(void)
+//{
+	//uint32_t status;
+	//status = can_mailbox_get_status(CAN0, TBD_CAN_RX_IDX);
+	//if ((status & CAN_MSR_MRDY) == CAN_MSR_MRDY) {
+		//can_mbox_up_rx.ul_mb_idx = TBD_CAN_RX_IDX;  // I don't know why or even if this is important
+		//can_mbox_up_rx.ul_status = status;
+		//can_mailbox_read(CAN0, &can_mbox_up_rx);
+		//g_can_down_receive_status = 1;
+	//}
+//}
 
-// Upstream
+// Upstream Receive Interrupt Handler
 void CAN1_Handler(void)
 {
 	uint32_t status;
@@ -49,30 +50,31 @@ void CAN1_Handler(void)
 
 uint8_t CANSetup(void)
 {
+	/*** CAN0 is downstream, CAN1 is upstream ***/
 
-	// enable CAN0 TX and RX pins
-	ioport_set_pin_mode(PIN_CAN0_RX_IDX, PIN_CAN0_RX_FLAGS);
+	// enable CAN0 (downstream) TX and RX pins
+	//ioport_set_pin_mode(PIN_CAN0_RX_IDX, PIN_CAN0_RX_FLAGS);
 	ioport_set_pin_mode(PIN_CAN0_TX_IDX, PIN_CAN0_TX_FLAGS);
 
-	// enable CAN1 TX and RX pins
+	// enable CAN1 (downstream) TX and RX pins
 	ioport_set_pin_mode(PIN_CAN1_RX_IDX, PIN_CAN1_RX_FLAGS);
-	ioport_set_pin_mode(PIN_CAN1_TX_IDX, PIN_CAN1_TX_FLAGS);
+	//ioport_set_pin_mode(PIN_CAN1_TX_IDX, PIN_CAN1_TX_FLAGS);
 	
-	/*** CAN0 is downstream, CAN1 is upstream ***/
-	
+	// Initialize the CAN peripheral clock	
 	pmc_enable_periph_clk(ID_CAN0);
 	pmc_enable_periph_clk(ID_CAN1);
-	
-	// If either call to can_init() fails, there is a bigger problem with the config
-	// or with the device itself and we need to abort
+
+	// Initialize the CAN peripherals
 	if (!can_init(TBD_CAN_DOWN, systemClk, TBD_CAN_BAUD))
-		return 0;
+		return FAILURE;
 	if (!can_init(TBD_CAN_UP, systemClk, TBD_CAN_BAUD))
-		return 0;
+		return FAILURE;
 	
+	// Reset the CAN mailboxes
 	can_reset_all_mailbox(TBD_CAN_DOWN);
 	can_reset_all_mailbox(TBD_CAN_UP);
 	
+	// Configure the downstream transmit mailbox
 	can_mbox_down_tx.ul_mb_idx = TBD_CAN_TX_IDX;
 	can_mbox_down_tx.uc_obj_type = CAN_MB_TX_MODE;
 	can_mbox_down_tx.uc_id_ver = 1;  // Extended ID
@@ -80,20 +82,23 @@ uint8_t CANSetup(void)
 	can_mbox_down_tx.ul_id = CAN_MID_MIDvA(TBD_CAN_DOWN_ADDR);  // TODO: Find proper masks for these
 	can_mailbox_init(TBD_CAN_DOWN, &can_mbox_down_tx);
 	
-	can_mbox_down_rx.ul_mb_idx = TBD_CAN_RX_IDX;
-	can_mbox_down_rx.uc_obj_type = CAN_MB_RX_OVER_WR_MODE;  // Receive, and overwrite
-	can_mbox_down_rx.uc_id_ver = 1;  // Extended ID
-	can_mbox_down_rx.ul_id_msk = 0;  // Accept all incoming IDs
-	can_mbox_down_rx.ul_id = CAN_MID_MIDvA(TBD_CAN_DOWN_ADDR);  // TODO: Find proper masks for these
-	can_mailbox_init(TBD_CAN_DOWN, &can_mbox_down_rx);
+	// Configure the downstream receive mailbox
+	//can_mbox_down_rx.ul_mb_idx = TBD_CAN_RX_IDX;
+	//can_mbox_down_rx.uc_obj_type = CAN_MB_RX_OVER_WR_MODE;  // Receive, and overwrite
+	//can_mbox_down_rx.uc_id_ver = 1;  // Extended ID
+	//can_mbox_down_rx.ul_id_msk = 0;  // Accept all incoming IDs
+	//can_mbox_down_rx.ul_id = CAN_MID_MIDvA(TBD_CAN_DOWN_ADDR);  // TODO: Find proper masks for these
+	//can_mailbox_init(TBD_CAN_DOWN, &can_mbox_down_rx);
+
+	// Configure the upstream transmit mailbox	
+	//can_mbox_up_tx.ul_mb_idx = TBD_CAN_TX_IDX;
+	//can_mbox_up_tx.uc_obj_type = CAN_MB_TX_MODE;
+	//can_mbox_up_tx.uc_id_ver = 1;  // Extended ID
+	//can_mbox_up_tx.ul_id_msk = 0;
+	//can_mbox_up_tx.ul_id = CAN_MID_MIDvA(TBD_CAN_UP_ADDR);  // TODO: Find proper masks for these
+	//can_mailbox_init(TBD_CAN_UP, &can_mbox_up_tx);
 	
-	can_mbox_up_tx.ul_mb_idx = TBD_CAN_TX_IDX;
-	can_mbox_up_tx.uc_obj_type = CAN_MB_TX_MODE;
-	can_mbox_up_tx.uc_id_ver = 1;  // Extended ID
-	can_mbox_up_tx.ul_id_msk = 0;
-	can_mbox_up_tx.ul_id = CAN_MID_MIDvA(TBD_CAN_UP_ADDR);  // TODO: Find proper masks for these
-	can_mailbox_init(TBD_CAN_UP, &can_mbox_up_tx);
-	
+	// Configure the upstream receive mailbox
 	can_mbox_up_rx.ul_mb_idx = TBD_CAN_RX_IDX;
 	can_mbox_up_rx.uc_obj_type = CAN_MB_RX_OVER_WR_MODE;
 	can_mbox_up_rx.uc_id_ver = 1;  // Extended ID
@@ -101,12 +106,13 @@ uint8_t CANSetup(void)
 	can_mbox_up_rx.ul_id = CAN_MID_MIDvA(TBD_CAN_UP_ADDR);  // TODO: Find proper masks for these
 	can_mailbox_init(TBD_CAN_UP, &can_mbox_up_rx);
 
-	NVIC_EnableIRQ(CAN0_IRQn);
+	// Enable CAN interrupts
+	//NVIC_EnableIRQ(CAN0_IRQn);
 	NVIC_EnableIRQ(CAN1_IRQn);
+	//can_enable_interrupt(TBD_CAN_DOWN, (1<<TBD_CAN_RX_IDX));
 	can_enable_interrupt(TBD_CAN_UP, (1<<TBD_CAN_RX_IDX));
-	can_enable_interrupt(TBD_CAN_DOWN, (1<<TBD_CAN_RX_IDX));
 
-	return 1;
+	return SUCCESS;
 }
 
 uint8_t CANSend(direction_t direction, uint32_t id, uint8_t length, const uint8_t *data)
@@ -114,16 +120,16 @@ uint8_t CANSend(direction_t direction, uint32_t id, uint8_t length, const uint8_
 	Can *can_module;
 	can_mb_conf_t *mbox;
 	switch (direction) {
-		case (Up):
-			can_module = TBD_CAN_UP;
-			mbox = &can_mbox_up_tx;
-			break;
+		//case (Up):
+			//can_module = TBD_CAN_UP;
+			//mbox = &can_mbox_up_tx;
+			//break;
 		case (Down):
 			can_module = TBD_CAN_DOWN;
 			mbox = &can_mbox_down_tx;
 			break;
 		default:
-			return 0;
+			return FAILURE;
 	}
 
 	mbox->ul_id = CAN_MID_MIDvA(id) | CAN_MID_MIDvB(id);
@@ -133,15 +139,14 @@ uint8_t CANSend(direction_t direction, uint32_t id, uint8_t length, const uint8_
 	}
 	mbox->uc_length = length;
 
-	uint32_t status;
-	while ((status = can_mailbox_write(can_module, mbox)) != CAN_MAILBOX_TRANSFER_OK) { }
+	uint32_t status = can_mailbox_write(can_module, mbox);
+
 	if (status == CAN_MAILBOX_TRANSFER_OK) {
 		can_mailbox_send_transfer_cmd(can_module, mbox);
-		return 1;
-	} else {
-		return 0;
+		return SUCCESS;
 	}
-
+	
+	return FAILURE;
 }
 
 uint8_t CANReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t **data)
@@ -153,16 +158,16 @@ uint8_t CANReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t
 			can_module = TBD_CAN_UP;
 			mbox = &can_mbox_up_rx;
 			break;
-		case (Down):
-			can_module = TBD_CAN_DOWN;
-			mbox = &can_mbox_down_rx;
-			break;
+		//case (Down):
+			//can_module = TBD_CAN_DOWN;
+			//mbox = &can_mbox_down_rx;
+			//break;
 		default:
-			return 0;
+			return FAILURE;
 	}
 	
 	if (!(can_mailbox_get_status(can_module, TBD_CAN_RX_IDX) & CAN_MSR_MRDY))
-		return 0;
+		return FAILURE;
 	
 	uint32_t status;
 	if ((status = can_mailbox_read(can_module, mbox)) == CAN_MAILBOX_TRANSFER_OK) {
@@ -173,12 +178,12 @@ uint8_t CANReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t
 			*data[i] = mbox->ul_datal & (0xff << 8*i);
 			*data[i+4] = mbox->ul_datah & (0xff << 8*i);
 		}
-		return 1;
+		return SUCCESS;
 	} else if (status & CAN_MAILBOX_RX_NEED_RD_AGAIN) {
 		// TODO Not sure what to do here - this indicates that a message was ignored or overridden
-		return 0;  // For now
+		return FAILURE;  // For now
 	}
 
-	return 0;
+	return FAILURE;
 	
 }

--- a/src/can.c
+++ b/src/can.c
@@ -195,8 +195,8 @@ uint8_t canReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t
 		// grab the CAN message payload length
 		*length = mbox->uc_length;
 		// grab the CAN message payload
-		memcpy(*data, mbox->ul_datal, sizeof(mbox->ul_datal));
-		memcpy(&((*data)[sizeof(mbox->ul_datal)]), mbox->ul_datah, sizeof(mbox->ul_datah));
+		memcpy(*data, &mbox->ul_datal, sizeof(mbox->ul_datal));
+		memcpy(&((*data)[sizeof(mbox->ul_datal)]), &mbox->ul_datah, sizeof(mbox->ul_datah));
 		return SUCCESS;
 	}
 	

--- a/src/can.c
+++ b/src/can.c
@@ -20,22 +20,22 @@ volatile uint32_t g_can_up_receive_status = 0;
 volatile uint32_t g_can_down_receive_status = 0;
 
 can_mb_conf_t can_mbox_down_tx = { 0 };
-//can_mb_conf_t can_mbox_down_rx = { 0 };
-//can_mb_conf_t can_mbox_up_tx = { 0 };
+can_mb_conf_t can_mbox_down_rx = { 0 };
+can_mb_conf_t can_mbox_up_tx = { 0 };
 can_mb_conf_t can_mbox_up_rx = { 0 };
 
 // Downstream Receive Interrupt Handler
-//void CAN0_Handler(void)
-//{
-	//uint32_t status;
-	//status = can_mailbox_get_status(CAN0, TBD_CAN_RX_IDX);
-	//if ((status & CAN_MSR_MRDY) == CAN_MSR_MRDY) {
-		//can_mbox_up_rx.ul_mb_idx = TBD_CAN_RX_IDX;  // I don't know why or even if this is important
-		//can_mbox_up_rx.ul_status = status;
-		//can_mailbox_read(CAN0, &can_mbox_up_rx);
-		//g_can_down_receive_status = 1;
-	//}
-//}
+void CAN0_Handler(void)
+{
+	uint32_t status;
+	status = can_mailbox_get_status(CAN0, TBD_CAN_RX_IDX);
+	if ((status & CAN_MSR_MRDY) == CAN_MSR_MRDY) {
+		can_mbox_up_rx.ul_mb_idx = TBD_CAN_RX_IDX;  // I don't know why or even if this is important
+		can_mbox_up_rx.ul_status = status;
+		can_mailbox_read(CAN0, &can_mbox_up_rx);
+		g_can_down_receive_status = 1;
+	}
+}
 
 // Upstream Receive Interrupt Handler
 void CAN1_Handler(void)
@@ -55,12 +55,12 @@ uint8_t CANSetup(void)
 	/*** CAN0 is downstream, CAN1 is upstream ***/
 
 	// enable CAN0 (downstream) TX and RX pins
-	//ioport_set_pin_mode(PIN_CAN0_RX_IDX, PIN_CAN0_RX_FLAGS);
+	ioport_set_pin_mode(PIN_CAN0_RX_IDX, PIN_CAN0_RX_FLAGS);
 	ioport_set_pin_mode(PIN_CAN0_TX_IDX, PIN_CAN0_TX_FLAGS);
 
 	// enable CAN1 (downstream) TX and RX pins
 	ioport_set_pin_mode(PIN_CAN1_RX_IDX, PIN_CAN1_RX_FLAGS);
-	//ioport_set_pin_mode(PIN_CAN1_TX_IDX, PIN_CAN1_TX_FLAGS);
+	ioport_set_pin_mode(PIN_CAN1_TX_IDX, PIN_CAN1_TX_FLAGS);
 	
 	// Initialize the CAN peripheral clock	
 	pmc_enable_periph_clk(ID_CAN0);
@@ -77,43 +77,45 @@ uint8_t CANSetup(void)
 	can_reset_all_mailbox(TBD_CAN_UP);
 	
 	// Configure the downstream transmit mailbox
-	can_mbox_down_tx.ul_mb_idx = TBD_CAN_TX_IDX;
-	can_mbox_down_tx.uc_obj_type = CAN_MB_TX_MODE;
-	can_mbox_down_tx.uc_tx_prio = 15;	// Default (lowest) priority
-	can_mbox_down_tx.uc_id_ver = 1;		// Extended ID
+	can_mbox_down_tx.ul_mb_idx = TBD_CAN_TX_IDX;				// Transmit Mailbox Index
+	can_mbox_down_tx.uc_obj_type = CAN_MB_TX_MODE;				// Transmit Mode
+	can_mbox_down_tx.uc_tx_prio = 15;							// Low priority
+	can_mbox_down_tx.uc_id_ver = 1;								// Extended ID
 	can_mbox_down_tx.ul_id_msk = 0;
-	//can_mbox_down_tx.ul_id = CAN_MID_MIDvB(TBD_CAN_DOWN_ADDR);	// Extended ID (is this needed for transmitter?)
+	can_mbox_down_tx.ul_id = CAN_MID_MIDvB(TBD_CAN_DOWN_ADDR);	// TODO: determine proper ID (unique?)
 	can_mailbox_init(TBD_CAN_DOWN, &can_mbox_down_tx);
 	
 	// Configure the downstream receive mailbox
-	//can_mbox_down_rx.ul_mb_idx = TBD_CAN_RX_IDX;
-	//can_mbox_down_rx.uc_obj_type = CAN_MB_RX_OVER_WR_MODE;  // Receive, and overwrite
-	//can_mbox_down_rx.uc_id_ver = 1;  // Extended ID
-	//can_mbox_down_rx.ul_id_msk = 0;  // Accept all incoming IDs
-	//can_mbox_down_rx.ul_id = CAN_MID_MIDvA(TBD_CAN_DOWN_ADDR);  // TODO: Find proper masks for these
-	//can_mailbox_init(TBD_CAN_DOWN, &can_mbox_down_rx);
+	can_mbox_down_rx.ul_mb_idx = TBD_CAN_RX_IDX;				// Receive Mailbox Index
+	can_mbox_down_rx.uc_obj_type = CAN_MB_RX_OVER_WR_MODE;		// Receive, and overwrite
+	can_mbox_down_rx.uc_id_ver = 1;								// Extended ID
+	//can_mbox_down_rx.ul_id_msk = 0;							// Accept all incoming IDs
+	can_mbox_down_rx.ul_id_msk = CAN_MAM_MIDvB_Msk;				// Accept extended ID frames TODO: accept only Digitizer messages?
+	can_mbox_down_rx.ul_id = CAN_MID_MIDvA(TBD_CAN_DOWN_ADDR);  // TODO: determine proper ID (unique?)
+	can_mailbox_init(TBD_CAN_DOWN, &can_mbox_down_rx);
 
 	// Configure the upstream transmit mailbox	
-	//can_mbox_up_tx.ul_mb_idx = TBD_CAN_TX_IDX;
-	//can_mbox_up_tx.uc_obj_type = CAN_MB_TX_MODE;
-	//can_mbox_up_tx.uc_id_ver = 1;  // Extended ID
-	//can_mbox_up_tx.ul_id_msk = 0;
-	//can_mbox_up_tx.ul_id = CAN_MID_MIDvA(TBD_CAN_UP_ADDR);  // TODO: Find proper masks for these
-	//can_mailbox_init(TBD_CAN_UP, &can_mbox_up_tx);
+	can_mbox_up_tx.ul_mb_idx = TBD_CAN_TX_IDX;					// Transmit Mailbox Index
+	can_mbox_up_tx.uc_obj_type = CAN_MB_TX_MODE;				// Transmit Mode
+	can_mbox_up_tx.uc_tx_prio = 10;								// High priority
+	can_mbox_up_tx.uc_id_ver = 1;								// Extended ID
+	can_mbox_up_tx.ul_id_msk = 0;
+	can_mbox_up_tx.ul_id = CAN_MID_MIDvA(TBD_CAN_UP_ADDR);		// TODO: determine proper ID (unique?)
+	can_mailbox_init(TBD_CAN_UP, &can_mbox_up_tx);
 	
 	// Configure the upstream receive mailbox
-	can_mbox_up_rx.ul_mb_idx = TBD_CAN_RX_IDX;
-	can_mbox_up_rx.uc_obj_type = CAN_MB_RX_OVER_WR_MODE;
-	can_mbox_up_rx.uc_id_ver = 1;  // Extended ID
-	//can_mbox_up_rx.ul_id_msk = 0;  // Accept all incoming IDs
-	can_mbox_up_rx.ul_id_msk = CAN_MAM_MIDvB_Msk;  // Accept extended ID frames
-	can_mbox_up_rx.ul_id = CAN_MID_MIDvB(TBD_CAN_UP_ADDR);  // TODO: Find proper masks for these
+	can_mbox_up_rx.ul_mb_idx = TBD_CAN_RX_IDX;					// Receive Mailbox Index
+	can_mbox_up_rx.uc_obj_type = CAN_MB_RX_OVER_WR_MODE;		// Receive & Overwrite
+	can_mbox_up_rx.uc_id_ver = 1;								// Extended ID
+	//can_mbox_up_rx.ul_id_msk = 0;								// Accept all incoming IDs
+	can_mbox_up_rx.ul_id_msk = CAN_MAM_MIDvB_Msk;				// Accept extended ID frames TODO: accept only Digitizer messages?
+	can_mbox_up_rx.ul_id = CAN_MID_MIDvB(TBD_CAN_UP_ADDR);		// TODO: determine proper ID (unique?)
 	can_mailbox_init(TBD_CAN_UP, &can_mbox_up_rx);
 
 	// Enable CAN interrupts
-	//NVIC_EnableIRQ(CAN0_IRQn);
+	NVIC_EnableIRQ(CAN0_IRQn);
 	NVIC_EnableIRQ(CAN1_IRQn);
-	//can_enable_interrupt(TBD_CAN_DOWN, (1<<TBD_CAN_RX_IDX));
+	can_enable_interrupt(TBD_CAN_DOWN, (1<<TBD_CAN_RX_IDX));
 	can_enable_interrupt(TBD_CAN_UP, (1<<TBD_CAN_RX_IDX));
 
 	return SUCCESS;
@@ -123,11 +125,13 @@ uint8_t CANSend(direction_t direction, uint32_t id, uint8_t length, const uint8_
 {
 	Can *can_module;
 	can_mb_conf_t *mbox;
+	
+	// determine which direction we're transmitting to
 	switch (direction) {
-		//case (Up):
-			//can_module = TBD_CAN_UP;
-			//mbox = &can_mbox_up_tx;
-			//break;
+		case (Up):
+			can_module = TBD_CAN_UP;
+			mbox = &can_mbox_up_tx;
+			break;
 		case (Down):
 			can_module = TBD_CAN_DOWN;
 			mbox = &can_mbox_down_tx;
@@ -135,12 +139,6 @@ uint8_t CANSend(direction_t direction, uint32_t id, uint8_t length, const uint8_
 		default:
 			return FAILURE;
 	}
-
-	//mbox->ul_id = CAN_MID_MIDvA(id) | CAN_MID_MIDvB(id);
-	//for (int i = 0; i < 4; i++) {
-		//mbox->ul_datal |= data[i] << (8*i);
-		//mbox->ul_datah |= data[i+4] << (8*i);
-	//}
 
 	// set the ID of the message
 	mbox->ul_id = CAN_MID_MIDvB(TBD_CAN_UP_ADDR);	// TODO: change id
@@ -152,22 +150,15 @@ uint8_t CANSend(direction_t direction, uint32_t id, uint8_t length, const uint8_
 	// set the length of the message
 	mbox->uc_length = length;
 
+	// get the status of the transmit mailbox
 	uint32_t write_status = can_mailbox_write(can_module, mbox);
 
-	uint32_t status = can_mailbox_get_status(can_module, TBD_CAN_TX_IDX);
-
+	// transmit the message in the mailbox if it's ready
 	if (write_status == CAN_MAILBOX_TRANSFER_OK) {
 		can_mailbox_send_transfer_cmd(can_module, mbox);
-
-		status = can_mailbox_get_status(can_module, TBD_CAN_TX_IDX);
-
 		return SUCCESS;
 	}
 
-	can_reset_all_mailbox(can_module);
-
-	status = can_mailbox_get_status(can_module, TBD_CAN_TX_IDX);
-	
 	return FAILURE;
 }
 
@@ -175,35 +166,42 @@ uint8_t CANReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t
 {
 	Can *can_module;
 	can_mb_conf_t *mbox;
+	
+	// determine which direction we're receiving from
 	switch (direction) {
 		case (Up):
 			can_module = TBD_CAN_UP;
 			mbox = &can_mbox_up_rx;
 			break;
-		//case (Down):
-			//can_module = TBD_CAN_DOWN;
-			//mbox = &can_mbox_down_rx;
-			//break;
+		case (Down):
+			can_module = TBD_CAN_DOWN;
+			mbox = &can_mbox_down_rx;
+			break;
 		default:
 			return FAILURE;
 	}
 	
+	// poll to see if there is a CAN message in the receive mailbox
 	if (!(can_mailbox_get_status(can_module, TBD_CAN_RX_IDX) & CAN_MSR_MRDY))
 		return FAILURE;
-	
+
+	// read the available message	
 	uint32_t status = can_mailbox_read(can_module, mbox);
 
-	if (status == CAN_MAILBOX_TRANSFER_OK) {
-		// Successful read
-		*id = mbox->ul_id;  // TODO does this need to be converted using CAN_MID_MIDvA/B?
+	// extract the CAN message properties
+	if (status & CAN_MAILBOX_TRANSFER_OK) {
+		// grab the CAN message ID
+		*id = mbox->ul_id;
+		// grab the CAN message payload length
 		*length = mbox->uc_length;
-		for (int i = 0; i < mbox->uc_length; i++) {
-			*data[i] = mbox->ul_datal & (0xff << 8*i);
-			*data[i+4] = mbox->ul_datah & (0xff << 8*i);
-		}
+		// grab the CAN message payload
+		memcpy(*data, mbox->ul_datal, sizeof(mbox->ul_datal));
+		memcpy(&((*data)[sizeof(mbox->ul_datal)]), mbox->ul_datah, sizeof(mbox->ul_datah));
 		return SUCCESS;
-	} else if (status & CAN_MAILBOX_RX_NEED_RD_AGAIN) {
-		// TODO Not sure what to do here - this indicates that a message was ignored or overridden
+	}
+	
+	else if (status & CAN_MAILBOX_RX_NEED_RD_AGAIN) {
+		// TODO Not sure what to do here - this indicates that a message was ignored or overridden. Do we care?
 		return FAILURE;  // For now
 	}
 

--- a/src/can.c
+++ b/src/can.c
@@ -50,7 +50,7 @@ void CAN1_Handler(void)
 	}
 }
 
-uint8_t CANSetup(void)
+uint8_t canInit(void)
 {
 	/*** CAN0 is downstream, CAN1 is upstream ***/
 
@@ -121,7 +121,7 @@ uint8_t CANSetup(void)
 	return SUCCESS;
 }
 
-uint8_t CANSend(direction_t direction, uint32_t id, uint8_t length, const uint8_t *data)
+uint8_t canTransmit(direction_t direction, uint32_t id, uint8_t length, const uint8_t *data)
 {
 	Can *can_module;
 	can_mb_conf_t *mbox;
@@ -162,7 +162,7 @@ uint8_t CANSend(direction_t direction, uint32_t id, uint8_t length, const uint8_
 	return FAILURE;
 }
 
-uint8_t CANReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t **data)
+uint8_t canReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t **data)
 {
 	Can *can_module;
 	can_mb_conf_t *mbox;

--- a/src/can.c
+++ b/src/can.c
@@ -49,29 +49,14 @@ void CAN1_Handler(void)
 
 uint8_t CANSetup(void)
 {
-	
-	#if (BOARD==SAM4E_XPLAINED_PRO)
-	
-	ioport_set_pin_mode(PIN_CAN1_RX_IDX, PIN_CAN1_RX_FLAGS);
-	// ioport_disable_pin(PIN_CAN1_RX_IDX);
-	ioport_set_pin_mode(PIN_CAN1_TX_IDX, PIN_CAN1_TX_FLAGS);
-	// ioport_disable_pin(PIN_CAN1_TX_IDX);
 
-	/* Configure the transiver1 RS & EN pins. */
-	ioport_set_pin_dir(PIN_CAN1_TR_RS_IDX, IOPORT_DIR_OUTPUT);
-	ioport_set_pin_dir(PIN_CAN1_TR_EN_IDX, IOPORT_DIR_OUTPUT);
+	// enable CAN0 TX and RX pins
+	ioport_set_pin_mode(PIN_CAN0_RX_IDX, PIN_CAN0_RX_FLAGS);
+	ioport_set_pin_mode(PIN_CAN0_TX_IDX, PIN_CAN0_TX_FLAGS);
 
-	#else // (BOARD==SAM4E_XPLAINED_PRO)
-	
+	// enable CAN1 TX and RX pins
 	ioport_set_pin_mode(PIN_CAN1_RX_IDX, PIN_CAN1_RX_FLAGS);
 	ioport_set_pin_mode(PIN_CAN1_TX_IDX, PIN_CAN1_TX_FLAGS);
-
-	/* Configure the transiver1 RS & EN pins. */
-	ioport_set_pin_dir(PIN_CAN1_TR_RS_IDX, IOPORT_DIR_OUTPUT);
-	ioport_set_pin_dir(PIN_CAN1_TR_EN_IDX, IOPORT_DIR_OUTPUT);
-	
-	#endif // (BOARD==SAM4E_XPLAINED_PRO)
-
 	
 	/*** CAN0 is downstream, CAN1 is upstream ***/
 	

--- a/src/command.c
+++ b/src/command.c
@@ -9,12 +9,12 @@
 
 uint8_t cmdSendUpstream(message_t *command)
 {
-	return CANSend(Up, command->id, command->length, (uint8_t *)command->data);
+	return canTransmit(Up, command->id, command->length, (uint8_t *)command->data);
 }
 
 uint8_t cmdReceiveDownstream(message_t *command)
 {
-	return CANReceive(Down, &command->id, &command->length, (uint8_t **)&command->data);
+	return canReceive(Down, &command->id, &command->length, (uint8_t **)&command->data);
 }
 
 uint8_t cmdHandle(message_t *command)

--- a/src/command.c
+++ b/src/command.c
@@ -33,6 +33,6 @@ uint8_t cmdHandle(message_t *command)
 		}
 	}
 
-	return 1;
+	return SUCCESS;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -49,9 +49,6 @@ int main (void)
 	uint32_t updatePeriod = 100 * 1000;
 	uint32_t loopTimer = 0;
 
-	int yay_rx = 0;
-	int yay_tx = 0;
-
 	while (1) {
 		
 		loopTimer++;
@@ -72,15 +69,12 @@ int main (void)
 			if (updateSendDownstream(&localUpdate) != SUCCESS) {
 				// Something went wrong with the transmission of the update
 				error++;
-			} else {
-				yay_tx++;
 			}
 		}
 
 
 		/*** CALIBRATION COMMANDS ***/
 
-		/*
 		// Poll for commands from downstream and respond accordingly
 		if (cmdReceiveDownstream(&command) != 0) {
 			if (!cmdSendUpstream(&command)) {
@@ -92,15 +86,12 @@ int main (void)
 				error++;
 			}
 		}
-		*/
 		
 		
 		/*** UPDATE FORWARDING ***/
 
 		// Poll for upstream updates
 		if (updateReceiveUpstream(&remoteUpdate) == SUCCESS) {
-			
-			yay_rx++;
 			
 			// Handle the update
 			if (updateHandle(&remoteUpdate) != SUCCESS) {

--- a/src/main.c
+++ b/src/main.c
@@ -42,14 +42,16 @@ int main (void)
 	// initialize the ADC
 	adcInit();
 
-	calibrationTareAllLoadCells();
+	//calibrationTareAllLoadCells();
 	
-	calibrationObtainMassOne(0);
+	//calibrationObtainMassOne(2.5);
 	
-	calibrationObtainMassTwo(5);
+	//calibrationObtainMassTwo(7.5);
 
-	uint32_t updatePeriod = 25 * 1000;
+	uint32_t updatePeriod = 15 * 1000;
 	uint32_t loopTimer = 0;
+
+	int yay = 0;
 
 	while (1) {
 		
@@ -71,6 +73,8 @@ int main (void)
 			if (updateSendDownstream(&localUpdate) != SUCCESS) {
 				// Something went wrong with the transmission of the update
 				error++;
+			} else {
+				yay++;
 			}
 		}
 
@@ -92,7 +96,7 @@ int main (void)
 				error++;
 			}
 		}
-		
+	
 		
 		/*** UPDATE FORWARDING ***/
 

--- a/src/main.c
+++ b/src/main.c
@@ -74,13 +74,17 @@ int main (void)
 
 		/*** CALIBRATION COMMANDS ***/
 
-		// Poll for commands from downstream and respond accordingly
-		if (cmdReceiveDownstream(&command) != 0) {
-			if (!cmdSendUpstream(&command)) {
+		// Poll for commands from downstream
+		if (cmdReceiveDownstream(&command) != SUCCESS) {
+			
+			// Forward the commands upstream
+			if (cmdSendUpstream(&command) != SUCCESS) {
 				// Something went wrong with the transmission of the command
 				error++;
 			}
-			if (!cmdHandle(&command)) {
+			
+			// Handle the command
+			if (cmdHandle(&command) != SUCCESS) {
 				// Something went wrong with the handling of this command
 				error++;
 			}
@@ -95,11 +99,10 @@ int main (void)
 			// Handle the update
 			if (updateHandle(&remoteUpdate) != SUCCESS) {
 		 		// Something went wrong with the update handling
-				error++;
-				
+				error++;	
 		 	}
 			 
-			// Forward the update downstream
+			// Forward the update downstream (if handling succeeded)
 			else if (updateSendDownstream(&remoteUpdate) != SUCCESS) {
 				// Something went wrong with the transmission of the update
 				error++;

--- a/src/main.c
+++ b/src/main.c
@@ -8,9 +8,6 @@
 #include <ioport.h>
 #include <tbd.h>
 
-extern can_mb_conf_t can_mbox_up_rx, can_mbox_up_tx;
-extern can_mb_conf_t can_mbox_down_rx, can_mbox_down_tx;
-
 uint32_t systemClk = 0;
 uint32_t cpuClk = 0;
 
@@ -45,7 +42,13 @@ int main (void)
 	// initialize the ADC
 	adcInit();
 
-	uint32_t updatePeriod = 100 * 1000;
+	calibrationTareAllLoadCells();
+	
+	calibrationObtainMassOne(0);
+	
+	calibrationObtainMassTwo(5);
+
+	uint32_t updatePeriod = 25 * 1000;
 	uint32_t loopTimer = 0;
 
 	while (1) {
@@ -59,7 +62,7 @@ int main (void)
 		if ((loopTimer % updatePeriod) == 0) {
 			
 			// Obtain ADC output
-			mass = (float) adcReadAllSmooth();
+			mass = (float) (adcReadAllSmooth() * calibrationConversionFactor());
 
 			// Create the new update message
 			updateCreate(&localUpdate, mass);

--- a/src/main.c
+++ b/src/main.c
@@ -18,7 +18,6 @@ message_t command = { 0 };
 message_t localUpdate = { 0 };
 message_t remoteUpdate = { 0 };
 
-uint8_t x = 0;
 
 int main (void)
 {
@@ -36,7 +35,7 @@ int main (void)
 	board_init();
 
 	// initialize the CAN peripheral
-	if (CANSetup() != SUCCESS) {
+	if (canInit() != SUCCESS) {
 		error++;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -49,11 +49,14 @@ int main (void)
 	uint32_t updatePeriod = 100 * 1000;
 	uint32_t loopTimer = 0;
 
+	int yay_rx = 0;
+	int yay_tx = 0;
+
 	while (1) {
 		
 		loopTimer++;
 
-		/*** UPDATE ACQUISITION TRANSMISSION ***/
+		/*** UPDATE ACQUISITION & TRANSMISSION ***/
 
 		// Check to see if it's time to sample the ADC output
 		// TODO: use an accurate timer
@@ -69,6 +72,8 @@ int main (void)
 			if (updateSendDownstream(&localUpdate) != SUCCESS) {
 				// Something went wrong with the transmission of the update
 				error++;
+			} else {
+				yay_tx++;
 			}
 		}
 
@@ -95,17 +100,20 @@ int main (void)
 		// Poll for upstream updates
 		if (updateReceiveUpstream(&remoteUpdate) == SUCCESS) {
 			
+			yay_rx++;
+			
 			// Handle the update
 			if (updateHandle(&remoteUpdate) != SUCCESS) {
 		 		// Something went wrong with the update handling
 				error++;
+				
 		 	}
-			
+			 
 			// Forward the update downstream
-		 	if (updateSendDownstream(&remoteUpdate) != SUCCESS) {
-		 		// Something went wrong with the transmission of the update
+			else if (updateSendDownstream(&remoteUpdate) != SUCCESS) {
+				// Something went wrong with the transmission of the update
 				error++;
-		 	}
+			}
 		}
 	}
 }

--- a/src/tbd.h
+++ b/src/tbd.h
@@ -75,7 +75,6 @@ void adcInit(void);
 int32_t adcReadAllChannels(void);
 int32_t adcReadAllSmooth(void);
 int32_t adcReadChannelSmooth(adcChannel_t channel);
-int32_t adcReadAndCalibrate(adcChannel_t channel);
 
 
 /*** CALIBRATION ***/

--- a/src/tbd.h
+++ b/src/tbd.h
@@ -14,7 +14,7 @@
 
 
 /*** CAN ***/
-#define TBD_CAN_BAUD CAN_BPS_500K
+#define TBD_CAN_BAUD CAN_BPS_250K
 
 #define TBD_CAN_DOWN CAN0
 #define TBD_CAN_UP   CAN1

--- a/src/tbd.h
+++ b/src/tbd.h
@@ -18,10 +18,19 @@
 
 #define TBD_CAN_DOWN CAN0
 #define TBD_CAN_UP   CAN1
+
 typedef enum {
 	Up,
 	Down
 } direction_t;
+
+#define CAN_MAX_PAYLOAD_SIZE	(8)
+
+typedef struct {
+	uint32_t id;
+	uint8_t length;
+	uint8_t data[CAN_MAX_PAYLOAD_SIZE];
+} message_t;
 
 #define TBD_CAN_TX_IDX (0)
 #define TBD_CAN_RX_IDX (1)
@@ -38,14 +47,14 @@ uint8_t CANReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t
 #define TBD_UPDATE_TANK_ID_IDX (0)
 
 typedef struct {
-	uint32_t id;
-	uint8_t length;
-	uint8_t data[8];
-} message_t;
+	uint8_t tankId;
+	float mass;
+} update_t;
 
-uint8_t updateSendDownstream(message_t *update);
-uint8_t updateReceiveUpstream(message_t *update);
-uint8_t updateHandle(message_t *update);
+uint8_t updateSendDownstream(message_t *message);
+uint8_t updateReceiveUpstream(message_t *message);
+uint8_t updateCreate(message_t *message, float mass);
+uint8_t updateHandle(message_t *message);
 
 
 /*** Command ***/
@@ -70,6 +79,7 @@ int32_t adcReadChannelSmooth(adcChannel_t channel);
 
 /*** CALIBRATION ***/
 int32_t calibrationOffset(adcChannel_t channel);
+
 void calibrationTare(adcChannel_t channel, int32_t offset);
 void calibrationTareAllLoadCells(void);
 void calibrationObtainMassOne(double mass);
@@ -78,7 +88,11 @@ void calibrationGetConversionFactor();
 
 
 /*** GENERAL ***/
+#define SUCCESS	(0)
+#define FAILURE	(1)
+
 #define LOAD_CELLS_PER_TANK	3
+
 void delayInit(void);
 void delayFor(uint32_t us);
 

--- a/src/tbd.h
+++ b/src/tbd.h
@@ -38,9 +38,9 @@ typedef struct {
 #define TBD_CAN_DOWN_ADDR (0x01)
 #define TBD_CAN_UP_ADDR   (0x02)
 
-uint8_t CANSetup(void);
-uint8_t CANSend(direction_t direction, uint32_t id, uint8_t length, const uint8_t *data);
-uint8_t CANReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t **data);
+uint8_t canInit(void);
+uint8_t canTransmit(direction_t direction, uint32_t id, uint8_t length, const uint8_t *data);
+uint8_t canReceive(direction_t direction, uint32_t *id, uint8_t *length, uint8_t **data);
 
 
 /*** Update ***/

--- a/src/tbd.h
+++ b/src/tbd.h
@@ -75,16 +75,18 @@ void adcInit(void);
 int32_t adcReadAllChannels(void);
 int32_t adcReadAllSmooth(void);
 int32_t adcReadChannelSmooth(adcChannel_t channel);
+int32_t adcReadAndCalibrate(adcChannel_t channel);
 
 
 /*** CALIBRATION ***/
 int32_t calibrationOffset(adcChannel_t channel);
+float calibrationConversionFactor(void);
 
 void calibrationTare(adcChannel_t channel, int32_t offset);
 void calibrationTareAllLoadCells(void);
-void calibrationObtainMassOne(double mass);
-void calibrationObtainMassTwo(double mass);
-void calibrationGetConversionFactor();
+
+void calibrationObtainMassOne(float mass);
+void calibrationObtainMassTwo(float mass);
 
 
 /*** GENERAL ***/

--- a/src/update.c
+++ b/src/update.c
@@ -6,20 +6,53 @@
  */ 
 
 #include <tbd.h>
+#include <string.h>
 
-uint8_t updateSendDownstream(message_t *update)
+
+uint8_t updateSendDownstream(message_t *message)
 {
-	return CANSend(Down, update->id, update->length, (uint8_t *)update->data);
+	return CANSend(Down, message->id, message->length, (uint8_t *)message->data);
 }
 
-uint8_t updateReceiveUpstream(message_t *update)
+uint8_t updateReceiveUpstream(message_t *message)
 {
-	return CANReceive(Up, &update->id, &update->length, (uint8_t **)update->data);
+	return CANReceive(Up, &message->id, &message->length, (uint8_t **)message->data);
 }
 
-uint8_t updateHandle(message_t *update)
+uint8_t updateCreate(message_t *message, float mass)
 {
-	++(update->data[TBD_UPDATE_TANK_ID_IDX]);  // TODO
-	return 1;
+	// Ensure message pointer is valid
+	if (message == NULL)
+		return FAILURE;
+	
+	// Clear previous contents of the message
+	memset(message, 0, sizeof(message_t));
+	
+	// Create a new update
+	update_t update = { 0 };
+		
+	// Initial ID of the message is 1		
+	update.tankId = 1;
+	
+	// Set the mass
+	update.mass = mass;
+	
+	// Copy the update into the message payload
+	memcpy(message->data, &update, sizeof(update_t));
+	
+	// Set the length of the message
+	message->length = sizeof(update_t);
+	
+	// Set the ID of the message
+	message->id = 1;
+	
+	return SUCCESS;
+}
+
+uint8_t updateHandle(message_t *message)
+{
+	// Increment the tank ID field
+	((update_t*)(message->data))->tankId++;
+	return SUCCESS;
 }
 

--- a/src/update.c
+++ b/src/update.c
@@ -11,12 +11,12 @@
 
 uint8_t updateSendDownstream(message_t *message)
 {
-	return CANSend(Down, message->id, message->length, (uint8_t *)message->data);
+	return canTransmit(Down, message->id, message->length, (uint8_t *)message->data);
 }
 
 uint8_t updateReceiveUpstream(message_t *message)
 {
-	return CANReceive(Up, &message->id, &message->length, (uint8_t **)message->data);
+	return canReceive(Up, &message->id, &message->length, (uint8_t **)message->data);
 }
 
 uint8_t updateCreate(message_t *message, float mass)


### PR DESCRIPTION
- Pulled in all of Thomas' changes from the recent PR into the `xplained` base branch
- Cleaned the ADC and CAN code up a bit per our coding standards (naming, bit of encapsulation)
- Changed a line in the `can.c` module that would block forever if a transmit mailbox wasn't ready
- Added an `update_t` type, and a function that populates it and turns it into a `message_t`
- Added the actual periodic sending of updates